### PR TITLE
removed powers loop parallelization   

### DIFF
--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1541,7 +1541,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     //
     // *note: force and dr are packed vectors of coordinates.
     omp_set_num_threads(16);
-    
+
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set
     
@@ -1624,7 +1624,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
 
     double force_scalar[npairs] ;
 
-    #pragma omp parallel for schedule(dynamic, 128) 
+    #pragma omp parallel for schedule(dynamic, 16) 
     for(int coeffs=0; coeffs<variablecoeff; coeffs++)
     {
                 

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,7 +1540,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
-    omp_set_num_threads(16);
+    omp_set_num_threads(8);
 
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set
@@ -1624,7 +1624,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
 
     double force_scalar[npairs] ;
 
-    #pragma omp parallel for reduction(+:energy) schedule(dynamic)
+    #pragma omp parallel for reduction(+:energy) schedule(dynamic, 30)
     for(int coeffs=0; coeffs<variablecoeff; coeffs++)
     {
                 

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,6 +1540,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
+    omp_set_num_threads(16);
     
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,7 +1540,6 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
-    omp_set_num_threads(2);
 
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set
@@ -1624,7 +1623,8 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
 
     double force_scalar[npairs] ;
 
-    #pragma omp parallel for reduction(+:energy) schedule(dynamic, 140)
+    // Note parallizing below loop will not improve performance as the overhead to spun new threads is more than the computation itself
+    // #pragma omp parallel for reduction(+:energy) schedule(dynamic, 140)
     for(int coeffs=0; coeffs<variablecoeff; coeffs++)
     {
                 

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,7 +1540,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
-    omp_set_num_threads(8);
+    omp_set_num_threads(2);
 
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set
@@ -1624,7 +1624,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
 
     double force_scalar[npairs] ;
 
-    #pragma omp parallel for reduction(+:energy) schedule(dynamic, 30)
+    #pragma omp parallel for reduction(+:energy) schedule(dynamic, 128)
     for(int coeffs=0; coeffs<variablecoeff; coeffs++)
     {
                 

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,7 +1540,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
-    omp_set_num_threads(4);
+    omp_set_num_threads(2);
 
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1624,7 +1624,9 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
 
     double force_scalar[npairs] ;
 
-    #pragma omp parallel for schedule(dynamic, 16) 
+    cout << "variablecoeff: " << variablecoeff << endl;
+    cout << "ncoeffs_3b_tripidx: " << ncoeffs_3b_tripidx << endl;
+    #pragma omp parallel for 
     for(int coeffs=0; coeffs<variablecoeff; coeffs++)
     {
                 

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,7 +1540,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
-    omp_set_num_threads(1);
+    omp_set_num_threads(2);
 
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set
@@ -1624,7 +1624,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
 
     double force_scalar[npairs] ;
 
-    #pragma omp parallel for reduction(+:energy)
+    #pragma omp parallel for reduction(+:energy) schedule(dynamic)
     for(int coeffs=0; coeffs<variablecoeff; coeffs++)
     {
                 

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1624,9 +1624,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
 
     double force_scalar[npairs] ;
 
-    cout << "variablecoeff: " << variablecoeff << endl;
-    cout << "ncoeffs_3b_tripidx: " << ncoeffs_3b_tripidx << endl;
-    #pragma omp parallel for 
+    #pragma omp parallel for reduction(+:energy)
     for(int coeffs=0; coeffs<variablecoeff; coeffs++)
     {
                 
@@ -1634,13 +1632,17 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
         powers[coeffs][1] = chimes_3b_powers[tripidx][coeffs][mapped_pair_idx[1]];
         powers[coeffs][2] = chimes_3b_powers[tripidx][coeffs][mapped_pair_idx[2]];
         
+        coeff = chimes_3b_params[tripidx][coeffs];
+        
+        energy += coeff * fcut_all * Tn_ij[ powers[coeffs][0] ] * Tn_ik[ powers[coeffs][1] ] * Tn_jk[ powers[coeffs][2] ];    
+
     }
 
     for(int coeffs=0; coeffs<ncoeffs_3b[tripidx]; coeffs++)
     {
         coeff = chimes_3b_params[tripidx][coeffs];
         
-        energy += coeff * fcut_all * Tn_ij[ powers[coeffs][0] ] * Tn_ik[ powers[coeffs][1] ] * Tn_jk[ powers[coeffs][2] ];    
+        // energy += coeff * fcut_all * Tn_ij[ powers[coeffs][0] ] * Tn_ik[ powers[coeffs][1] ] * Tn_jk[ powers[coeffs][2] ];    
 
         deriv[0] = fcut[0] * Tnd_ij[ powers[coeffs][0] ] + fcutderiv[0] * Tn_ij[ powers[coeffs][0] ];
         deriv[1] = fcut[1] * Tnd_ik[ powers[coeffs][1] ] + fcutderiv[1] * Tn_ik[ powers[coeffs][1] ];

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,7 +1540,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
-    omp_set_num_threads(2);
+    omp_set_num_threads(1);
 
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,7 +1540,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
-    omp_set_num_threads(2);
+    omp_set_num_threads(16);
 
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1540,7 +1540,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     // Assumes distances are atom_2 - atom_1
     //
     // *note: force and dr are packed vectors of coordinates.
-    omp_set_num_threads(16);
+    omp_set_num_threads(4);
 
     const int natoms = 3;                   // Number of atoms in an interaction set
     const int npairs = natoms*(natoms-1)/2; // Number of pairs in an interaction set

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1624,7 +1624,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
 
     double force_scalar[npairs] ;
 
-    #pragma omp parallel for reduction(+:energy) schedule(dynamic, 128)
+    #pragma omp parallel for reduction(+:energy) schedule(dynamic, 140)
     for(int coeffs=0; coeffs<variablecoeff; coeffs++)
     {
                 

--- a/serial_interface/examples/cpp/Makefile
+++ b/serial_interface/examples/cpp/Makefile
@@ -1,5 +1,5 @@
 
-CXX   = nvc++  -fopenmp -O2 -std=c++17
+CXX   = nvc++  -fopenmp -O2 -std=c++17 --diag_suppress declared_but_not_referenced
 DEBUG = 1
 
 CXX_LOC = $(realpath .)


### PR DESCRIPTION
Observed overhead to spun new threads is more than the computation itself for `compute_3b`